### PR TITLE
Remove unnecessary unsafe

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,9 +37,15 @@ jobs:
   tests:
     name: Tests
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        toolchain: ["1.83", "stable", "nightly"]
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@nightly
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: "${{ matrix.toolchain }}"
       - uses: taiki-e/install-action@cargo-hack
       - uses: Swatinem/rust-cache@v2
       - name: Run tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,7 +49,7 @@ jobs:
       - uses: taiki-e/install-action@cargo-hack
       - uses: Swatinem/rust-cache@v2
       - name: Run tests
-        run: cargo hack test --feature-powerset
+        run: cargo hack test --feature-powerset ${{ matrix.toolchain == 'stable' && '-- --include-ignored' }}
 
   miri:
     name: Miri

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -124,7 +124,7 @@ where
     crate::stream::init(|mut yielder: TryYielder<_, _>| async move {
         // trivially copyable. bit-wise copy is fine.
         #[allow(unsafe_code)]
-            if let Err(err) = func(unsafe { core::ptr::read(&raw const yielder) }).await {
+        if let Err(err) = func(unsafe { core::ptr::read(&raw const yielder) }).await {
             yielder.yield_error(err).await;
         }
     })

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -124,7 +124,7 @@ where
     crate::stream::init(|mut yielder: TryYielder<_, _>| async move {
         // trivially copyable. bit-wise copy is fine.
         #[allow(unsafe_code)]
-        if let Err(err) = func(unsafe { core::ptr::read(&yielder) }).await {
+            if let Err(err) = func(unsafe { core::ptr::read(&raw const yielder) }).await {
             yielder.yield_error(err).await;
         }
     })

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -1,7 +1,6 @@
 use crate::yielder::Yielder;
 use core::{
     future::Future,
-    hint::unreachable_unchecked,
     marker::PhantomData,
     pin::Pin,
     ptr,
@@ -62,8 +61,7 @@ where
                     // this state is never initialized with `func` set to `None`.
                     //
                     // we actually only do this to be able to use `.take()` to remove the function from the future.
-                    #[allow(unsafe_code)]
-                    let func = unsafe { func.take().unwrap_unchecked() };
+                    let func = func.take().expect("function already taken");
                     let fut = func(<_>::from(Yielder::new(stream_address)));
 
                     self.set(Self::Progress { fut });
@@ -83,12 +81,7 @@ where
                 }
                 AsynkStrimProj::Done => break Poll::Ready(None),
                 AsynkStrimProj::MarkerStuff { .. } => {
-                    // the state machine will never enter this state.
-                    // documented on the state machine level.
-                    #[allow(unsafe_code)]
-                    unsafe {
-                        unreachable_unchecked()
-                    }
+                    unreachable!("reached marker state");
                 }
             }
         }

--- a/src/waker.rs
+++ b/src/waker.rs
@@ -24,7 +24,7 @@ static WAKER_VTABLE: RawWakerVTable =
 #[allow(unsafe_code)]
 unsafe fn waker_clone(data: *const ()) -> RawWaker {
     // we are inside the waker vtable context and the void pointer points to our data struct
-    let inner_waker = unsafe { &*data.cast::<WakerData<'_>>() }
+    let inner_waker = unsafe { data.cast::<WakerData<'_>>().as_ref().unwrap() }
         .inner_waker
         .clone();
     let inner_waker = ManuallyDrop::new(inner_waker);
@@ -39,7 +39,7 @@ fn waker_wake(_data: *const ()) {
 #[allow(unsafe_code)]
 unsafe fn waker_wake_by_ref(data: *const ()) {
     // we are inside the waker vtable context and the void pointer points to our data struct
-    let inner_waker = unsafe { &*data.cast::<WakerData<'_>>() }.inner_waker;
+    let inner_waker = unsafe { data.cast::<WakerData<'_>>().as_ref().unwrap() }.inner_waker;
     inner_waker.wake_by_ref();
 }
 
@@ -55,15 +55,9 @@ fn get_waker_data(waker: &Waker) -> Option<&WakerData<'_>> {
         return None;
     }
 
-    // we never set the data to null or a dangling pointer.
+    // we never set the data to a dangling pointer.
     #[allow(unsafe_code)]
-    let data = unsafe {
-        waker
-            .data()
-            .cast::<WakerData<'_>>()
-            .as_ref()
-            .unwrap_unchecked()
-    };
+    let data = unsafe { waker.data().cast::<WakerData<'_>>().as_ref().unwrap() };
 
     Some(data)
 }

--- a/tests/ui.rs
+++ b/tests/ui.rs
@@ -1,5 +1,6 @@
 #[cfg(not(miri))]
 #[test]
+#[ignore = "only run on stable pls"]
 fn tests() {
     let t = trybuild::TestCases::new();
     t.compile_fail("tests/ui/*.rs");


### PR DESCRIPTION
This PR removes unnecessary unsafe code and uses the libcore `ptr` functions with null checks wherever applicable.